### PR TITLE
AN-2932/missing-txns

### DIFF
--- a/models/silver/base_goerli/methods/silver_goerli__receipts_method.sql
+++ b/models/silver/base_goerli/methods/silver_goerli__receipts_method.sql
@@ -67,7 +67,7 @@ base AS (
             '-32008',
             '-32009',
             '-32010'
-        ) qualify(ROW_NUMBER() over (PARTITION BY block_number
+        ) qualify(ROW_NUMBER() over (PARTITION BY block_number, response
     ORDER BY
         _inserted_timestamp DESC)) = 1
 ),
@@ -154,3 +154,5 @@ SELECT
 FROM flat_response f
 LEFT JOIN logs_response l USING(parent_transactionHash)
 WHERE _log_id IS NOT NULL
+QUALIFY ROW_NUMBER() OVER (PARTITION BY _log_id 
+    ORDER BY _inserted_timestamp DESC) = 1

--- a/models/silver/base_goerli/methods/silver_goerli__receipts_method.sql
+++ b/models/silver/base_goerli/methods/silver_goerli__receipts_method.sql
@@ -67,9 +67,7 @@ base AS (
             '-32008',
             '-32009',
             '-32010'
-        ) qualify(ROW_NUMBER() over (PARTITION BY block_number, response
-    ORDER BY
-        _inserted_timestamp DESC)) = 1
+        ) 
 ),
 
 flat_response AS (


### PR DESCRIPTION
- Modified/added QUALIFY statement(s) to 1) restore missing transactions and 2) resolve dupes
- `receipts_method` requires FR+ all dependent models