### PR TITLE
AH-2950/receipts-tx-lvl

### DIFF
--- a/models/silver/base_goerli/methods/silver_goerli__receipts_method.sql
+++ b/models/silver/base_goerli/methods/silver_goerli__receipts_method.sql
@@ -1,8 +1,7 @@
  {{ config (
     materialized = "incremental",
     unique_key = "tx_hash",
-    cluster_by = "ROUND(block_number, -3)",
-    merge_update_columns = ["tx_hash"]
+    cluster_by = "ROUND(block_number, -3)"
 ) }}
 
 WITH meta AS (

--- a/models/silver/base_goerli/methods/silver_goerli__receipts_method.yml
+++ b/models/silver/base_goerli/methods/silver_goerli__receipts_method.yml
@@ -4,7 +4,7 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - _LOG_ID
+            - TX_HASH
     columns:
       - name: BLOCK_NUMBER
         tests:

--- a/models/silver/base_goerli/silver_goerli__logs.sql
+++ b/models/silver/base_goerli/silver_goerli__logs.sql
@@ -4,12 +4,40 @@
     cluster_by = "ROUND(block_number, -3)"
 ) }}
 
-WITH flat_base AS (
+WITH logs_response AS (
+
+SELECT
+	block_number,
+    blockHash AS block_hash,
+    logs_array,
+	VALUE :address :: STRING AS contract_address,
+    VALUE :data :: STRING AS data,
+    ethereum.public.udf_hex_to_int(
+    	VALUE :logIndex :: STRING) :: INTEGER AS event_index,
+    VALUE :removed :: STRING AS removed,
+    VALUE :topics AS topics,
+    VALUE :transactionHash :: STRING AS tx_hash,
+    VALUE :transactionIndex :: STRING AS transactionIndex,
+    origin_from_address,
+    origin_to_address,
+    status,
+    type,
+    CONCAT(
+        tx_hash,
+        '-',
+        event_index
+    ) AS _log_id,
+    _inserted_timestamp
+FROM {{ ref('silver_goerli__receipts_method') }},
+    LATERAL FLATTEN(input => logs_array)
+),
+
+flat_base AS (
 
     SELECT
         _log_id,
         block_number,
-        blockHash AS block_hash,
+        block_hash,
         tx_hash,
         origin_from_address,
         CASE
@@ -36,12 +64,10 @@ WITH flat_base AS (
         ) :: INTEGER AS TYPE,
         _inserted_timestamp
     FROM
-        {{ ref('silver_goerli__receipts_method') }}
-    WHERE
-        tx_hash IS NOT NULL
+        logs_response
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
+WHERE _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp

--- a/models/silver/base_goerli/silver_goerli__logs.sql
+++ b/models/silver/base_goerli/silver_goerli__logs.sql
@@ -30,6 +30,16 @@ SELECT
     _inserted_timestamp
 FROM {{ ref('silver_goerli__receipts_method') }},
     LATERAL FLATTEN(input => logs_array)
+{% if is_incremental() %}
+WHERE _inserted_timestamp >= (
+    SELECT
+        MAX(
+            _inserted_timestamp
+        )
+    FROM
+        {{ this }}
+)
+{% endif %}
 ),
 
 flat_base AS (
@@ -65,17 +75,6 @@ flat_base AS (
         _inserted_timestamp
     FROM
         logs_response
-
-{% if is_incremental() %}
-WHERE _inserted_timestamp >= (
-    SELECT
-        MAX(
-            _inserted_timestamp
-        )
-    FROM
-        {{ this }}
-)
-{% endif %}
 ),
 new_records AS (
     SELECT

--- a/models/silver/base_goerli/silver_goerli__transactions.sql
+++ b/models/silver/base_goerli/silver_goerli__transactions.sql
@@ -135,7 +135,7 @@ WITH flat_base AS (
         t
         JOIN {{ ref('silver_goerli__receipts_method') }}
         l
-        ON t.tx_hash = l.parent_transactionHash
+        ON t.tx_hash = l.tx_hash
 
 {% if is_incremental() %}
 WHERE
@@ -262,8 +262,6 @@ SELECT
     is_pending,
     _inserted_timestamp
 FROM new_records
-qualify(ROW_NUMBER() over (PARTITION BY tx_hash
-    ORDER BY _inserted_timestamp)) = 1
 
 {% if is_incremental() %}
 UNION


### PR DESCRIPTION
1. Modeled `receipts_method` at the tx level
2. Flattened logs in silver `logs`
3. Removed qualify statement from silver `transactions`
4. `receipts_method`, `logs`, `transactions` require FR+