### PR TITLE
fix/hex-to-int-bug

### DIFF
--- a/models/silver/base_goerli/silver_goerli__transactions.sql
+++ b/models/silver/base_goerli/silver_goerli__transactions.sql
@@ -104,8 +104,7 @@ WITH flat_base AS (
             ) :: INTEGER,
             0
         ) AS effective_gas_price,
-        COALESCE(
-            ethereum.public.udf_hex_to_int(
+        COALESCE((
                 l1FeeScalar :: STRING
             ) :: FLOAT,
             0


### PR DESCRIPTION
1. removed hex_to_int conversion on `l1feescalar` column to resolve incremental failure