### PR TITLE
AN-3977/delete-insert-update

### DIFF
--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -49,5 +49,5 @@ jobs:
   
       - name: Execute block_reorg macro
         run: |
-          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}" && grep -E "SQL status|/* {" logs/dbt.log
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}" && awk '/SQL status/ {print; next} /DELETE FROM/{getline; print} /\/\* {/ {print}' logs/dbt.log
         

--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -1,0 +1,53 @@
+name: dbt_run_operation_reorg
+run-name: dbt_run_operation_reorg
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at minute 45 every 8 hours (see https://crontab.guru)
+    - cron: '45 */8 * * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+
+      - name: List reorg models
+        id: list_models
+        run: |
+          reorg_model_list=$(dbt list --select tag:reorg --resource-type model | awk -F'.' '{print $NF}' | tr '\n' ',' | sed 's/,$//')
+          echo "::set-output name=model_list::$reorg_model_list"
+  
+      - name: Execute block_reorg macro
+        run: |
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}" && grep -E "SQL status|/* {" logs/dbt.log
+        

--- a/models/bronze/ethereum/bronze__state_hashes.sql
+++ b/models/bronze/ethereum/bronze__state_hashes.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "state_tx_hash",
+    incremental_strategy = 'delete+insert',
+    unique_key = "state_block_number",
     tags = ['ethereum','non_realtime']
 ) }}
 

--- a/models/gold/core/core__ez_eth_transfers.sql
+++ b/models/gold/core/core__ez_eth_transfers.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['core','non_realtime'],
     persist_docs ={ "relation": true,
     "columns": true }

--- a/models/gold/core/core__ez_eth_transfers.sql
+++ b/models/gold/core/core__ez_eth_transfers.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['core','non_realtime'],
+    tags = ['core','non_realtime','reorg'],
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -3,11 +3,9 @@
     materialized = "incremental",
     unique_key = ['block_number', 'event_index'],
     cluster_by = "block_timestamp::date",
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     full_refresh = false,
-    tags = ['decoded_logs']
+    tags = ['decoded_logs','reorg']
 ) }}
 
 WITH base_data AS (

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -3,7 +3,9 @@
     materialized = "incremental",
     unique_key = ['block_number', 'event_index'],
     cluster_by = "block_timestamp::date",
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     full_refresh = false,
     tags = ['decoded_logs']
 ) }}

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH logs AS (

--- a/models/silver/defi/dex/aerodrome/silver_dex__aerodrome_pools.sql
+++ b/models/silver/defi/dex/aerodrome/silver_dex__aerodrome_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     tags = ['non_realtime']
 ) }}
 
@@ -31,7 +32,7 @@ WITH created_pools AS(
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/aerodrome/silver_dex__aerodrome_swaps.sql
+++ b/models/silver/defi/dex/aerodrome/silver_dex__aerodrome_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/aerodrome/silver_dex__aerodrome_swaps.sql
+++ b/models/silver/defi/dex/aerodrome/silver_dex__aerodrome_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/defi/dex/aerodrome/silver_dex__aerodrome_swaps.sql
+++ b/models/silver/defi/dex/aerodrome/silver_dex__aerodrome_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -61,7 +62,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/defi/dex/balancer/silver_dex__balancer_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     tags = ['non_realtime']
 ) }}
 
@@ -33,7 +34,7 @@ WITH pools_registered AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/defi/dex/balancer/silver_dex__balancer_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/defi/dex/balancer/silver_dex__balancer_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -63,7 +64,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/defi/dex/balancer/silver_dex__balancer_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pool_name AS (

--- a/models/silver/defi/dex/baseswap/silver_dex__baseswap_pools.sql
+++ b/models/silver/defi/dex/baseswap/silver_dex__baseswap_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/baseswap/silver_dex__baseswap_swaps.sql
+++ b/models/silver/defi/dex/baseswap/silver_dex__baseswap_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/baseswap/silver_dex__baseswap_swaps.sql
+++ b/models/silver/defi/dex/baseswap/silver_dex__baseswap_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/defi/dex/baseswap/silver_dex__baseswap_swaps.sql
+++ b/models/silver/defi/dex/baseswap/silver_dex__baseswap_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -62,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     tags = ['non_realtime']
 ) }}
 --    full_refresh = false,
@@ -32,7 +33,7 @@ WITH contract_deployments AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 3
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "_log_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -81,7 +82,7 @@ curve_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -149,7 +150,7 @@ token_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pool_meta AS (

--- a/models/silver/defi/dex/dackieswap/silver_dex__dackie_pools.sql
+++ b/models/silver/defi/dex/dackieswap/silver_dex__dackie_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -37,7 +38,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -65,7 +66,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/dackieswap/silver_dex__dackie_swaps.sql
+++ b/models/silver/defi/dex/dackieswap/silver_dex__dackie_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/dackieswap/silver_dex__dackie_swaps.sql
+++ b/models/silver/defi/dex/dackieswap/silver_dex__dackie_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -44,7 +45,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/dackieswap/silver_dex__dackie_swaps.sql
+++ b/models/silver/defi/dex/dackieswap/silver_dex__dackie_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base_swaps AS (

--- a/models/silver/defi/dex/maverick/silver_dex__maverick_pools.sql
+++ b/models/silver/defi/dex/maverick/silver_dex__maverick_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     tags = ['non_realtime']
 ) }}
 
@@ -53,7 +54,7 @@ WITH pools AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/maverick/silver_dex__maverick_swaps.sql
+++ b/models/silver/defi/dex/maverick/silver_dex__maverick_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/maverick/silver_dex__maverick_swaps.sql
+++ b/models/silver/defi/dex/maverick/silver_dex__maverick_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/defi/dex/maverick/silver_dex__maverick_swaps.sql
+++ b/models/silver/defi/dex/maverick/silver_dex__maverick_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -88,7 +89,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -3,8 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-  tags = ['non_realtime']
+  tags = ['non_realtime','reorg']
 ) }}
 
 WITH contracts AS (

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -3,6 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
+  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
   tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = "_id",
+  incremental_strategy = 'delete+insert',
+  unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
   tags = ['non_realtime']
 ) }}
@@ -24,6 +25,7 @@ curve AS (
     pool_address,
     pool_name,
     'curve' AS platform,
+    'v1' AS version,
     _call_id AS _id,
     _inserted_timestamp,
     MAX(
@@ -73,7 +75,7 @@ curve AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -90,6 +92,7 @@ balancer AS (
     pool_address,
     pool_name,
     'balancer' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp,
     token0,
@@ -107,7 +110,7 @@ balancer AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -125,6 +128,7 @@ uni_v3 AS (
     token0_address AS token0,
     token1_address AS token1,
     'uniswap-v3' AS platform,
+    'v3' AS version,
     _id,
     _inserted_timestamp
   FROM
@@ -134,7 +138,7 @@ uni_v3 AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -152,6 +156,7 @@ dackieswap AS (
     token0_address AS token0,
     token1_address AS token1,
     'dackieswap' AS platform,
+    'v1' AS version,
     _id,
     _inserted_timestamp
   FROM
@@ -161,7 +166,7 @@ dackieswap AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -179,6 +184,7 @@ sushi AS (
     token0_address AS token0,
     token1_address AS token1,
     'sushiswap' AS platform,
+    'v1' AS version,
     _id,
     _inserted_timestamp
   FROM
@@ -188,7 +194,7 @@ sushi AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -205,6 +211,7 @@ maverick AS (
     tokenA AS token0,
     tokenB AS token1,
     'maverick' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
   FROM
@@ -214,7 +221,7 @@ maverick AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -231,6 +238,7 @@ swapbased AS (
     token0,
     token1,
     'swapbased' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
   FROM
@@ -240,7 +248,7 @@ swapbased AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -257,6 +265,7 @@ aerodrome AS (
     token0,
     token1,
     'aerodrome' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
   FROM
@@ -266,7 +275,7 @@ aerodrome AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -283,6 +292,7 @@ baseswap AS (
     token0,
     token1,
     'baseswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
   FROM
@@ -292,7 +302,7 @@ baseswap AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -386,6 +396,7 @@ FINAL AS (
       c1.decimals
     ) AS decimals,
     platform,
+    version,
     _id,
     p._inserted_timestamp
   FROM
@@ -488,6 +499,7 @@ FINAL AS (
       c1.decimals
     ) AS decimals,
     platform,
+    version,
     _id,
     p._inserted_timestamp
   FROM
@@ -592,6 +604,7 @@ FINAL AS (
       c7.decimals
     ) AS decimals,
     platform,
+    version,
     _id,
     p._inserted_timestamp
   FROM
@@ -618,6 +631,7 @@ SELECT
   block_timestamp,
   tx_hash,
   platform,
+  version,
   contract_address,
   pool_address,
   pool_name,

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -3,8 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-  tags = ['non_realtime']
+  tags = ['non_realtime','reorg']
 ) }}
 
 WITH contracts AS (

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -3,6 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
+  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
   tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = "_log_id",
+  incremental_strategy = 'delete+insert',
+  unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
   tags = ['non_realtime']
 ) }}
@@ -29,15 +30,6 @@ prices AS (
       FROM
         contracts
     )
-
-{% if is_incremental() %}
-AND HOUR >= (
-  SELECT
-    MAX(_inserted_timestamp) :: DATE - 2
-  FROM
-    {{ this }}
-)
-{% endif %}
 ),
 curve_swaps AS (
   SELECT
@@ -55,6 +47,7 @@ curve_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     COALESCE(
@@ -101,7 +94,7 @@ curve_swaps AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
   SELECT
-    MAX(_inserted_timestamp) :: DATE
+    MAX(_inserted_timestamp) - INTERVAL '36 hours'
   FROM
     {{ this }}
 )
@@ -160,6 +153,7 @@ dackie_swaps AS (
     recipient AS tx_to,
     event_index,
     'dackieswap' AS platform,
+    'v1' AS version,
     CASE
       WHEN amount0_unadj > 0 THEN token0_address
       ELSE token1_address
@@ -202,7 +196,7 @@ dackie_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -261,6 +255,7 @@ univ3_swaps AS (
     recipient AS tx_to,
     event_index,
     'uniswap-v3' AS platform,
+    'v3' AS version,
     CASE
       WHEN amount0_unadj > 0 THEN token0_address
       ELSE token1_address
@@ -303,7 +298,7 @@ univ3_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -362,6 +357,7 @@ sushi_swaps AS (
     recipient AS tx_to,
     event_index,
     'sushiswap' AS platform,
+    'v1' AS version,
     CASE
       WHEN amount0_unadj > 0 THEN token0_address
       ELSE token1_address
@@ -404,7 +400,7 @@ sushi_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -438,6 +434,7 @@ maverick_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -455,7 +452,7 @@ maverick_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -489,6 +486,7 @@ woofi_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     CONCAT(
@@ -528,7 +526,7 @@ woofi_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -563,6 +561,7 @@ balancer_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     _log_id,
@@ -579,7 +578,7 @@ balancer_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -613,6 +612,7 @@ baseswap AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -630,7 +630,7 @@ baseswap AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -664,6 +664,7 @@ swapbased AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -681,7 +682,7 @@ swapbased AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -715,6 +716,7 @@ aerodrome AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -732,7 +734,7 @@ aerodrome AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -758,6 +760,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -787,6 +790,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -816,6 +820,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -845,6 +850,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     token_symbol_in AS symbol_in,
@@ -874,6 +880,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -903,6 +910,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -932,6 +940,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -965,6 +974,7 @@ all_dex_custom AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -994,6 +1004,7 @@ all_dex_custom AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1023,6 +1034,7 @@ all_dex_custom AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1065,6 +1077,7 @@ FINAL AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1112,6 +1125,7 @@ FINAL AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1154,6 +1168,7 @@ SELECT
   tx_to,
   event_index,
   f.platform,
+  f.version,
   token_in,
   token_out,
   symbol_in,

--- a/models/silver/defi/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/defi/dex/sushi/silver_dex__sushi_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -64,8 +65,8 @@ initial_info AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 2
+                _inserted_timestamp
+            ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -44,7 +45,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base_swaps AS (

--- a/models/silver/defi/dex/swapbased/silver_dex__swapbased_pools.sql
+++ b/models/silver/defi/dex/swapbased/silver_dex__swapbased_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/swapbased/silver_dex__swapbased_swaps.sql
+++ b/models/silver/defi/dex/swapbased/silver_dex__swapbased_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/swapbased/silver_dex__swapbased_swaps.sql
+++ b/models/silver/defi/dex/swapbased/silver_dex__swapbased_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/defi/dex/swapbased/silver_dex__swapbased_swaps.sql
+++ b/models/silver/defi/dex/swapbased/silver_dex__swapbased_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -62,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/defi/dex/uniswap/silver_dex__univ3_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -37,7 +38,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -64,8 +65,8 @@ initial_info AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 2
+                _inserted_timestamp
+            ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -45,7 +46,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base_swaps AS (

--- a/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
@@ -2,6 +2,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     cluster_by = ['block_timestamp::DATE']
 ) }}
 

--- a/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE']
 ) }}
 
@@ -68,7 +69,7 @@ WITH router_swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -143,7 +144,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
@@ -2,8 +2,8 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    cluster_by = ['block_timestamp::DATE']
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH router_swaps_base AS (

--- a/models/silver/ethereum/silver__state_hashes.sql
+++ b/models/silver/ethereum/silver__state_hashes.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['state_block_timestamp::DATE'],
     tags = ['ethereum','non_realtime']

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = ['block_number','platform_name','platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH nft_base_models AS (

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -114,15 +114,6 @@ prices_raw AS (
                 nft_base_models
         )
         AND token_address != '0x4200000000000000000000000000000000000006'
-
-{% if is_incremental() %}
-AND HOUR >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
-    FROM
-        {{ this }}
-)
-{% endif %}
 ),
 eth_price AS (
     SELECT

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = ['block_number','platform_name','platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -1,8 +1,8 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    merge_update_columns = ["_log_id"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
     tags = ['non_realtime']
 ) }}

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -3,7 +3,9 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -3,10 +3,8 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
-    tags = ['non_realtime']
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base AS (

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH seaport_fees_wallet AS (

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -31,8 +32,8 @@ raw_decoded_logs AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+                _inserted_timestamp
+            ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -91,8 +92,8 @@ raw_logs AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+                _inserted_timestamp
+            ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1657,8 +1658,8 @@ mao_orderhash AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+                _inserted_timestamp
+            ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1700,8 +1701,8 @@ nft_transfer_operator AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+                _inserted_timestamp
+            ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__zeroex_sales.sql
+++ b/models/silver/nft/silver__zeroex_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH raw_logs AS (

--- a/models/silver/nft/silver__zeroex_sales.sql
+++ b/models/silver/nft/silver__zeroex_sales.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__zeroex_sales.sql
+++ b/models/silver/nft/silver__zeroex_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -78,8 +79,8 @@ WITH raw_logs AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+                _inserted_timestamp
+            ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -118,8 +119,8 @@ token_transfers_raw AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+                _inserted_timestamp
+            ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -181,8 +182,8 @@ eth_transfers_raw AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+                _inserted_timestamp
+            ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -324,8 +325,8 @@ tx_data AS (
 AND _inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+                _inserted_timestamp
+            ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/prices/silver__hourly_prices_priority.sql
+++ b/models/silver/prices/silver__hourly_prices_priority.sql
@@ -30,8 +30,8 @@ WHERE
 AND p._inserted_timestamp >= (
     SELECT
         MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+                _inserted_timestamp
+            ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.6.0
+    revision: v1.6.1
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.5.0
+    revision: v1.6.0
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.6.1
+    revision: v1.6.2
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]


### PR DESCRIPTION
1. Changes incremental strategy to delete+insert on `block_number` in majority of logs based downstream models
2. Minimizes incremental lookback to rolling 12-24 hrs vs 1-3 days, with exceptions
3. FR required on woofi_swaps, complete_dex_swaps, complete_dex_liquidity_pools to add `version` columns
4. Adds new workflow for block reorg macro, scheduled to run 3x daily - based on `reorg` tag