### PR TITLE
new columns

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -50,7 +50,8 @@ query-comment:
 
 models:
   +copy_grants: true
-
+  +on_schema_change: "append_new_columns"
+  
 # In this example config, we tell dbt to build all models in the example/ directory
 # as tables. These settings can be overridden in the individual model files
 # using the `{{ config(...) }}` macro.

--- a/models/doc_descriptions/general/deprecation.md
+++ b/models/doc_descriptions/general/deprecation.md
@@ -1,11 +1,11 @@
 {% docs internal_column %}    
 
-Deprecated. This column is no longer used. Please remove from your query by Jan. 10 2024.
+Deprecated. This column is no longer used. Please remove from your query by Jan. 31 2024.
 
 {% enddocs %}
 
 {% docs amount_deprecation %}   
 
-This column is being deprecated for standardization purposes on Jan. 10 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `eth_amount`.
+This column is being deprecated for standardization purposes on Jan. 31 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `eth_amount`.
 
 {% enddocs %}

--- a/models/doc_descriptions/general/deprecation.md
+++ b/models/doc_descriptions/general/deprecation.md
@@ -1,0 +1,11 @@
+{% docs internal_column %}    
+
+Deprecated. This column is no longer used. Please remove from your query by 01/01/2024.
+
+{% enddocs %}
+
+{% docs amount_deprecation %}   
+
+This column is being deprecated for standardization purposes. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `eth_amount`.
+
+{% enddocs %}

--- a/models/doc_descriptions/general/deprecation.md
+++ b/models/doc_descriptions/general/deprecation.md
@@ -1,11 +1,11 @@
 {% docs internal_column %}    
 
-Deprecated. This column is no longer used. Please remove from your query by 01/01/2024.
+Deprecated. This column is no longer used. Please remove from your query by Jan. 3rd, 2024.'
 
 {% enddocs %}
 
 {% docs amount_deprecation %}   
 
-This column is being deprecated for standardization purposes. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `eth_amount`.
+This column is being deprecated for standardization purposes on Jan. 3rd, 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `eth_amount`.
 
 {% enddocs %}

--- a/models/doc_descriptions/general/deprecation.md
+++ b/models/doc_descriptions/general/deprecation.md
@@ -1,11 +1,11 @@
 {% docs internal_column %}    
 
-Deprecated. This column is no longer used. Please remove from your query by Jan. 3rd, 2024.'
+Deprecated. This column is no longer used. Please remove from your query by Jan. 10 2024.
 
 {% enddocs %}
 
 {% docs amount_deprecation %}   
 
-This column is being deprecated for standardization purposes on Jan. 3rd, 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `eth_amount`.
+This column is being deprecated for standardization purposes on Jan. 10 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `eth_amount`.
 
 {% enddocs %}

--- a/models/doc_descriptions/general/export_columns.md
+++ b/models/doc_descriptions/general/export_columns.md
@@ -16,8 +16,4 @@ The utc timestamp at which the row was last modified.
 
 {% enddocs %}
 
-{% docs internal_column %}    
 
-Deprecated. This column is no longer used. Please remove from your query by 01/01/2024.
-
-{% enddocs %}

--- a/models/doc_descriptions/general/export_columns.md
+++ b/models/doc_descriptions/general/export_columns.md
@@ -1,0 +1,23 @@
+{% docs pk %}
+
+The unique identifier for each row in the table.
+
+{% enddocs %}
+
+{% docs inserted_timestamp %}
+
+The utc timestamp at which the row was inserted into the table.
+
+{% enddocs %}
+
+{% docs modified_timestamp %}
+
+The utc timestamp at which the row was last modified.
+
+{% enddocs %}
+
+{% docs internal_column %}    
+
+Deprecated. This column is no longer used. Please remove from your query by 01/01/2024.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_intra_event_index.md
+++ b/models/doc_descriptions/nft/nft_intra_event_index.md
@@ -1,0 +1,5 @@
+{% docs nft_intra_event_index %}
+
+The order of events within a single event index. This is primarily used for ERC1155 NFT batch transfer events. 
+
+{% enddocs %}

--- a/models/doc_descriptions/traces/base_traces_index.md
+++ b/models/doc_descriptions/traces/base_traces_index.md
@@ -1,0 +1,5 @@
+{% docs base_trace_index %}
+
+The index of the trace within the transaction.
+
+{% enddocs %}

--- a/models/gold/core/core__dim_contracts.sql
+++ b/models/gold/core/core__dim_contracts.sql
@@ -12,7 +12,23 @@ SELECT
     c0.block_number AS created_block_number,
     c0.block_timestamp AS created_block_timestamp,
     c0.tx_hash AS created_tx_hash,
-    c0.creator_address AS creator_address
+    c0.creator_address AS creator_address,
+    COALESCE (
+        c0.created_contracts_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['c0.created_contract_address']
+        ) }}
+    ) AS dim_contracts_id,
+    GREATEST(
+        c0.inserted_timestamp,
+        c1.inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    GREATEST(
+        c0.modified_timestamp,
+        c1.modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__created_contracts') }}
     c0

--- a/models/gold/core/core__dim_contracts.sql
+++ b/models/gold/core/core__dim_contracts.sql
@@ -19,16 +19,8 @@ SELECT
             ['c0.created_contract_address']
         ) }}
     ) AS dim_contracts_id,
-    GREATEST(
-        c0.inserted_timestamp,
-        c1.inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    GREATEST(
-        c0.modified_timestamp,
-        c1.modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    GREATEST(COALESCE(c0.inserted_timestamp, '2000-01-01'), COALESCE(c1.inserted_timestamp, '2000-01-01')) AS inserted_timestamp,
+    GREATEST(COALESCE(c0.modified_timestamp, '2000-01-01'), COALESCE(c1.modified_timestamp, '2000-01-01')) AS modified_timestamp
 FROM
     {{ ref('silver__created_contracts') }}
     c0

--- a/models/gold/core/core__dim_contracts.yml
+++ b/models/gold/core/core__dim_contracts.yml
@@ -20,3 +20,9 @@ models:
         description: 'The transaction hash when the contract was created'
       - name: CREATOR_ADDRESS
         description: 'The address of the creator of the contract'
+      - name: DIM_CONTRACTS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  

--- a/models/gold/core/core__dim_labels.sql
+++ b/models/gold/core/core__dim_labels.sql
@@ -11,6 +11,20 @@ SELECT
     address_name,
     label_type,
     label_subtype,
-    project_name
+    project_name,
+    COALESCE (
+        labels_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['address']
+        ) }}
+    ) AS dim_labels_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__labels') }}

--- a/models/gold/core/core__dim_labels.yml
+++ b/models/gold/core/core__dim_labels.yml
@@ -50,4 +50,10 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
+      - name: DIM_LABELS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  
 

--- a/models/gold/core/core__ez_decoded_event_logs.sql
+++ b/models/gold/core/core__ez_decoded_event_logs.sql
@@ -20,7 +20,24 @@ SELECT
     topics,
     DATA,
     event_removed,
-    tx_status
+    tx_status,
+    COALESCE (
+        decoded_logs_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS ez_decoded_event_logs_id,
+    GREATEST(
+        l.inserted_timestamp,
+        C.inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    GREATEST(
+        l.modified_timestamp,
+        C.modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
-    {{ ref('silver__decoded_logs') }} 
-    LEFT JOIN {{ ref('silver__contracts') }} using (contract_address)
+    {{ ref('silver__decoded_logs') }}
+    l
+    LEFT JOIN {{ ref('silver__contracts') }} C USING (contract_address)

--- a/models/gold/core/core__ez_decoded_event_logs.sql
+++ b/models/gold/core/core__ez_decoded_event_logs.sql
@@ -27,16 +27,8 @@ SELECT
             ['tx_hash', 'event_index']
         ) }}
     ) AS ez_decoded_event_logs_id,
-    GREATEST(
-        l.inserted_timestamp,
-        C.inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    GREATEST(
-        l.modified_timestamp,
-        C.modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp
+    GREATEST(COALESCE(l.inserted_timestamp, '2000-01-01'), COALESCE(C.inserted_timestamp, '2000-01-01')) AS inserted_timestamp,
+    GREATEST(COALESCE(l.modified_timestamp, '2000-01-01'), COALESCE(C.modified_timestamp, '2000-01-01')) AS modified_timestamp
 FROM
     {{ ref('silver__decoded_logs') }}
     l

--- a/models/gold/core/core__ez_decoded_event_logs.yml
+++ b/models/gold/core/core__ez_decoded_event_logs.yml
@@ -57,3 +57,9 @@ models:
         description: '{{ doc("base_event_removed") }}' 
       - name: TX_STATUS
         description: '{{ doc("base_tx_status") }}' 
+      - name: EZ_DECODED_EVENT_LOGS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__ez_eth_transfers.sql
+++ b/models/gold/core/core__ez_eth_transfers.sql
@@ -1,104 +1,26 @@
 {{ config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = 'block_number',
-    cluster_by = ['block_timestamp::DATE'],
-    tags = ['core','non_realtime','reorg'],
+    materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}
 
-WITH eth_base AS (
-
-    SELECT
-        tx_hash,
-        block_number,
-        block_timestamp,
-        identifier,
-        from_address,
-        to_address,
-        eth_value,
-        _call_id,
-        _inserted_timestamp,
-        eth_value_precise_raw,
-        eth_value_precise,
-        tx_position,
-        trace_index
-    FROM
-        {{ ref('silver__traces') }}
-    WHERE
-        eth_value > 0
-        AND tx_status = 'SUCCESS'
-        AND trace_status = 'SUCCESS'
-        AND TYPE NOT IN (
-            'DELEGATECALL',
-            'STATICCALL'
-        )
-
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '72 hours'
-    FROM
-        {{ this }}
-)
-{% endif %}
-),
-tx_table AS (
-    SELECT
-        block_number,
-        tx_hash,
-        from_address AS origin_from_address,
-        to_address AS origin_to_address,
-        origin_function_signature
-    FROM
-        {{ ref('silver__transactions') }}
-    WHERE
-        tx_hash IN (
-            SELECT
-                DISTINCT tx_hash
-            FROM
-                eth_base
-        )
-
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '72 hours'
-    FROM
-        {{ this }}
-)
-{% endif %}
-)
 SELECT
-    tx_hash AS tx_hash,
-    block_number AS block_number,
-    block_timestamp AS block_timestamp,
-    identifier AS identifier,
+    tx_hash,
+    block_number,
+    block_timestamp,
+    identifier,
     origin_from_address,
     origin_to_address,
     origin_function_signature,
     from_address AS eth_from_address,
     to_address AS eth_to_address,
-    eth_value AS amount,
-    eth_value_precise_raw AS amount_precise_raw,
-    eth_value_precise AS amount_precise,
-    ROUND(
-        eth_value * price,
-        2
-    ) AS amount_usd,
+    amount,
+    amount_precise_raw,
+    amount_precise,
+    amount_usd,
     _call_id,
     _inserted_timestamp,
     tx_position,
     trace_index
 FROM
-    eth_base A
-    LEFT JOIN {{ ref('silver__hourly_prices_priority_eth') }}
-    ON DATE_TRUNC(
-        'hour',
-        A.block_timestamp
-    ) = HOUR
-    JOIN tx_table USING (
-        tx_hash,
-        block_number
-    )
+    {{ ref('silver__native_transfers') }}

--- a/models/gold/core/core__ez_eth_transfers.yml
+++ b/models/gold/core/core__ez_eth_transfers.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: core__ez_eth_transfers
-    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 10 2024.'
+    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 31 2024.'
       
     columns:
       - name: BLOCK_NUMBER

--- a/models/gold/core/core__ez_eth_transfers.yml
+++ b/models/gold/core/core__ez_eth_transfers.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: core__ez_eth_transfers
-    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 3rd, 2024.'
+    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 10 2024.'
       
     columns:
       - name: BLOCK_NUMBER

--- a/models/gold/core/core__ez_eth_transfers.yml
+++ b/models/gold/core/core__ez_eth_transfers.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: core__ez_eth_transfers
-    description: 'Deprecating soon! Use `core.ez_native_transfers` instead.'
+    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 3rd, 2024.'
       
     columns:
       - name: BLOCK_NUMBER

--- a/models/gold/core/core__ez_native_transfers.sql
+++ b/models/gold/core/core__ez_native_transfers.sql
@@ -8,6 +8,8 @@ SELECT
     tx_hash,
     block_number,
     block_timestamp,
+    tx_position,
+    trace_index,
     identifier,
     origin_from_address,
     origin_to_address,
@@ -19,10 +21,6 @@ SELECT
     amount_precise_raw,
     amount_precise,
     amount_usd,
-    _call_id,
-    _inserted_timestamp,
-    tx_position,
-    trace_index,
     COALESCE (
         native_transfers_id,
         {{ dbt_utils.generate_surrogate_key(

--- a/models/gold/core/core__ez_native_transfers.sql
+++ b/models/gold/core/core__ez_native_transfers.sql
@@ -16,7 +16,6 @@ SELECT
     origin_function_signature,
     from_address,
     to_address,
-    'ETH' AS symbol,
     amount,
     amount_precise_raw,
     amount_precise,

--- a/models/gold/core/core__ez_native_transfers.sql
+++ b/models/gold/core/core__ez_native_transfers.sql
@@ -5,34 +5,29 @@
 ) }}
 
 SELECT
+    tx_hash,
     block_number,
     block_timestamp,
-    tx_hash,
-    event_index,
-    origin_function_signature,
+    identifier,
     origin_from_address,
     origin_to_address,
-    contract_address,
+    origin_function_signature,
     from_address,
     to_address,
-    raw_amount_precise,
-    raw_amount,
-    amount_precise,
     amount,
+    amount_precise_raw,
+    amount_precise,
     amount_usd,
-    decimals,
-    symbol,
-    token_price,
-    has_decimal,
-    has_price,
-    _log_id,
+    _call_id,
     _inserted_timestamp,
+    tx_position,
+    trace_index,
     COALESCE (
-        transfers_id,
+        native_transfers_id,
         {{ dbt_utils.generate_surrogate_key(
-            ['tx_hash', 'event_index']
+            ['tx_hash', 'trace_index']
         ) }}
-    ) AS ez_token_transfers_id,
+    ) AS ez_native_transfers_id,
     COALESCE(
         inserted_timestamp,
         '2000-01-01'
@@ -42,4 +37,4 @@ SELECT
         '2000-01-01'
     ) AS modified_timestamp
 FROM
-    {{ ref('silver__transfers') }}
+    {{ ref('silver__native_transfers') }}

--- a/models/gold/core/core__ez_native_transfers.sql
+++ b/models/gold/core/core__ez_native_transfers.sql
@@ -14,6 +14,7 @@ SELECT
     origin_function_signature,
     from_address,
     to_address,
+    'ETH' AS symbol,
     amount,
     amount_precise_raw,
     amount_precise,

--- a/models/gold/core/core__ez_native_transfers.yml
+++ b/models/gold/core/core__ez_native_transfers.yml
@@ -40,3 +40,7 @@ models:
         description: '{{ doc("inserted_timestamp") }}'   
       - name: MODIFIED_TIMESTAMP
         description: '{{ doc("modified_timestamp") }}' 
+      - name: _CALL_ID
+        description: '{{ doc("internal_column") }}'
+      - name: _INSERTED_TIMESTAMP
+        description: '{{ doc("internal_column") }}'

--- a/models/gold/core/core__ez_native_transfers.yml
+++ b/models/gold/core/core__ez_native_transfers.yml
@@ -4,43 +4,41 @@ models:
     description: '{{ doc("base_ez_eth_transfers_table_doc") }}'
       
     columns:
+      - name: TX_HASH
+        description: '{{ doc("base_transfer_tx_hash") }}'
       - name: BLOCK_NUMBER
         description: '{{ doc("base_block_number") }}'
       - name: BLOCK_TIMESTAMP
         description: '{{ doc("base_block_timestamp") }}'
-      - name: TX_HASH
-        description: '{{ doc("base_transfer_tx_hash") }}'
-      - name: FROM_ADDRESS
-        description: '{{ doc("base_transfer_from_address") }}'
-      - name: TO_ADDRESS
-        description: '{{ doc("base_transfer_to_address") }}'
-      - name: AMOUNT
-        description: '{{ doc("base_eth_amount") }}'
-      - name: TOKEN_PRICE
-        description: '{{ doc("base_transfer_token_price") }}'
-      - name: AMOUNT_USD
-        description: '{{ doc("base_eth_amount_usd") }}' 
-      - name: HAS_PRICE
-        description: '{{ doc("base_transfer_has_price") }}' 
-      - name: ORIGIN_FUNCTION_SIGNATURE
-        description: '{{ doc("base_origin_sig") }}'
+      - name: TX_POSITION
+        description: '{{ doc("base_tx_position") }}'
+      - name: TRACE_INDEX
+        description: '{{ doc("base_trace_index") }}'
+      - name: IDENTIFIER
+        description: '{{ doc("base_traces_identifier") }}'
       - name: ORIGIN_FROM_ADDRESS
         description: '{{ doc("base_origin_from") }}'
       - name: ORIGIN_TO_ADDRESS
         description: '{{ doc("base_origin_to") }}'
-      - name: IDENTIFIER
-        description: '{{ doc("base_traces_identifier") }}'
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        description: '{{ doc("base_origin_sig") }}'
+      - name: FROM_ADDRESS
+        description: '{{ doc("base_transfer_from_address") }}'
+      - name: TO_ADDRESS
+        description: '{{ doc("base_transfer_to_address") }}'
+      - name: SYMBOL
+        description: 'Native asset symbol, e.g. `ETH`'
+      - name: AMOUNT
+        description: '{{ doc("base_eth_amount") }}'
       - name: AMOUNT_PRECISE_RAW
         description: '{{ doc("precise_amount_unadjusted") }}'
       - name: AMOUNT_PRECISE
         description: '{{ doc("precise_amount_adjusted") }}'
+      - name: AMOUNT_USD
+        description: '{{ doc("base_eth_amount_usd") }}' 
       - name: EZ_NATIVE_TRANSFERS_ID
         description: '{{ doc("pk") }}'   
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
       - name: MODIFIED_TIMESTAMP
         description: '{{ doc("modified_timestamp") }}' 
-      - name: _CALL_ID
-        description: '{{ doc("internal_column") }}'
-      - name: _INSERTED_TIMESTAMP
-        description: '{{ doc("internal_column") }}'

--- a/models/gold/core/core__ez_native_transfers.yml
+++ b/models/gold/core/core__ez_native_transfers.yml
@@ -26,8 +26,6 @@ models:
         description: '{{ doc("base_transfer_from_address") }}'
       - name: TO_ADDRESS
         description: '{{ doc("base_transfer_to_address") }}'
-      - name: SYMBOL
-        description: 'Native asset symbol, e.g. `ETH`'
       - name: AMOUNT
         description: '{{ doc("base_eth_amount") }}'
       - name: AMOUNT_PRECISE_RAW

--- a/models/gold/core/core__ez_native_trnasfers.yml
+++ b/models/gold/core/core__ez_native_trnasfers.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
-  - name: core__ez_eth_transfers
-    description: 'Deprecating soon! Use `core.ez_native_transfers` instead.'
+  - name: core__ez_native_transfers
+    description: '{{ doc("base_ez_eth_transfers_table_doc") }}'
       
     columns:
       - name: BLOCK_NUMBER
@@ -10,9 +10,9 @@ models:
         description: '{{ doc("base_block_timestamp") }}'
       - name: TX_HASH
         description: '{{ doc("base_transfer_tx_hash") }}'
-      - name: ETH_FROM_ADDRESS
+      - name: FROM_ADDRESS
         description: '{{ doc("base_transfer_from_address") }}'
-      - name: ETH_TO_ADDRESS
+      - name: TO_ADDRESS
         description: '{{ doc("base_transfer_to_address") }}'
       - name: AMOUNT
         description: '{{ doc("base_eth_amount") }}'
@@ -34,3 +34,9 @@ models:
         description: '{{ doc("precise_amount_unadjusted") }}'
       - name: AMOUNT_PRECISE
         description: '{{ doc("precise_amount_adjusted") }}'
+      - name: EZ_NATIVE_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__ez_token_transfers.yml
+++ b/models/gold/core/core__ez_token_transfers.yml
@@ -45,7 +45,9 @@ models:
       - name: HAS_PRICE
         description: '{{ doc("base_transfer_has_price") }}'
       - name: _LOG_ID
-        description: '{{ doc("base_log_id_transfers") }}'
+        description: '{{ doc("internal_column") }}'
+      - name: _INSERTED_TIMESTAMP
+        description: '{{ doc("internal_column") }}'
       - name: EZ_TOKEN_TRANSFERS_ID
         description: '{{ doc("pk") }}'   
       - name: INSERTED_TIMESTAMP

--- a/models/gold/core/core__ez_token_transfers.yml
+++ b/models/gold/core/core__ez_token_transfers.yml
@@ -46,3 +46,9 @@ models:
         description: '{{ doc("base_transfer_has_price") }}'
       - name: _LOG_ID
         description: '{{ doc("base_log_id_transfers") }}'
+      - name: EZ_TOKEN_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_blocks.sql
+++ b/models/gold/core/core__fact_blocks.sql
@@ -67,13 +67,25 @@ SELECT
             ['a.block_number']
         ) }}
     ) AS fact_blocks_id,
-    COALESCE(
-        inserted_timestamp,
-        '2000-01-01'
+    GREATEST(
+        COALESCE(
+            A.inserted_timestamp,
+            '2000-01-01'
+        ),
+        COALESCE(
+            d.inserted_timestamp,
+            '2000-01-01'
+        )
     ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
-        '2000-01-01'
+    GREATEST(
+        COALESCE(
+            A.modified_timestamp,
+            '2000-01-01'
+        ),
+        COALESCE(
+            d.modified_timestamp,
+            '2000-01-01'
+        )
     ) AS modified_timestamp
 FROM
     {{ ref('silver__blocks') }} A

--- a/models/gold/core/core__fact_blocks.sql
+++ b/models/gold/core/core__fact_blocks.sql
@@ -60,7 +60,21 @@ SELECT
         transactions_root,
         'uncles',
         uncles
-    ) AS block_header_json
+    ) AS block_header_json,
+    COALESCE (
+        blocks_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['a.block_number']
+        ) }}
+    ) AS fact_blocks_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__blocks') }} A
     LEFT JOIN {{ ref('silver__tx_count') }}

--- a/models/gold/core/core__fact_blocks.yml
+++ b/models/gold/core/core__fact_blocks.yml
@@ -38,3 +38,9 @@ models:
         description: '{{ doc("base_uncle_blocks") }}' 
       - name: BLOCK_HEADER_JSON
         description: '{{ doc("base_block_header_json") }}'
+      - name: FACT_BLOCKS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/gold/core/core__fact_decoded_event_logs.sql
+++ b/models/gold/core/core__fact_decoded_event_logs.sql
@@ -12,6 +12,20 @@ SELECT
     contract_address,
     event_name,
     decoded_flat AS decoded_log,
-    decoded_data AS full_decoded_log
+    decoded_data AS full_decoded_log,
+    COALESCE (
+        decoded_logs_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS fact_decoded_event_logs_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__decoded_logs') }}

--- a/models/gold/core/core__fact_decoded_event_logs.yml
+++ b/models/gold/core/core__fact_decoded_event_logs.yml
@@ -41,3 +41,9 @@ models:
         description: 'The flattened decoded log, where the keys are the names of the event parameters, and the values are the values of the event parameters.'
       - name: FULL_DECODED_LOG
         description: 'The full decoded log, including the event name, the event parameters, and the data type of the event parameters.'  
+      - name: FACT_DECODED_EVENT_LOGS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_event_logs.sql
+++ b/models/gold/core/core__fact_event_logs.sql
@@ -17,6 +17,20 @@ SELECT
     DATA,
     event_removed,
     tx_status,
-    _log_id
+    _log_id,
+    COALESCE (
+        logs_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS fact_event_logs_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__logs') }}

--- a/models/gold/core/core__fact_event_logs.yml
+++ b/models/gold/core/core__fact_event_logs.yml
@@ -30,3 +30,9 @@ models:
         description: '{{ doc("base_origin_from") }}'
       - name: ORIGIN_TO_ADDRESS
         description: '{{ doc("base_origin_to") }}'
+      - name: FACT_EVENT_LOGS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_event_logs.yml
+++ b/models/gold/core/core__fact_event_logs.yml
@@ -21,7 +21,7 @@ models:
       - name: EVENT_REMOVED
         description: '{{ doc("base_event_removed") }}'  
       - name: _LOG_ID
-        description: '{{ doc("base_log_id_events") }}'  
+        description: '{{ doc("internal_column") }}'
       - name: TX_STATUS
         description: '{{ doc("base_tx_status") }}' 
       - name: ORIGIN_FUNCTION_SIGNATURE

--- a/models/gold/core/core__fact_token_transfers.sql
+++ b/models/gold/core/core__fact_token_transfers.sql
@@ -17,6 +17,20 @@ SELECT
     to_address,
     raw_amount,
     raw_amount_precise,
-    _log_id
+    _log_id,
+    COALESCE (
+        transfers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS fact_token_transfers_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__transfers') }}

--- a/models/gold/core/core__fact_token_transfers.yml
+++ b/models/gold/core/core__fact_token_transfers.yml
@@ -30,3 +30,9 @@ models:
         description: '{{ doc("base_transfer_raw_amount_precise") }}'
       - name: _LOG_ID
         description: '{{ doc("base_log_id_transfers") }}'
+      - name: FACT_TOKEN_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_token_transfers.yml
+++ b/models/gold/core/core__fact_token_transfers.yml
@@ -29,7 +29,7 @@ models:
       - name: RAW_AMOUNT_PRECISE
         description: '{{ doc("base_transfer_raw_amount_precise") }}'
       - name: _LOG_ID
-        description: '{{ doc("base_log_id_transfers") }}'
+        description: '{{ doc("internal_column") }}'
       - name: FACT_TOKEN_TRANSFERS_ID
         description: '{{ doc("pk") }}'   
       - name: INSERTED_TIMESTAMP

--- a/models/gold/core/core__fact_traces.sql
+++ b/models/gold/core/core__fact_traces.sql
@@ -30,7 +30,7 @@ SELECT
         {{ dbt_utils.generate_surrogate_key(
             ['tx_hash', 'trace_index']
         ) }}
-    ) AS fact_token_traces_id,
+    ) AS fact_traces_id,
     COALESCE(
         inserted_timestamp,
         '2000-01-01'

--- a/models/gold/core/core__fact_traces.sql
+++ b/models/gold/core/core__fact_traces.sql
@@ -10,9 +10,9 @@ SELECT
     block_timestamp,
     from_address,
     to_address,
-    eth_value,
-    eth_value_precise_raw,
-    eth_value_precise,
+    eth_value AS VALUE,
+    eth_value_precise_raw AS value_precise_raw,
+    eth_value_precise AS value_precise,
     gas,
     gas_used,
     input,
@@ -24,6 +24,23 @@ SELECT
     sub_traces,
     trace_status,
     error_reason,
-    trace_index
+    trace_index,
+    COALESCE (
+        traces_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'trace_index']
+        ) }}
+    ) AS fact_token_traces_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp,
+    eth_value,
+    eth_value_precise_raw,
+    eth_value_precise
 FROM
     {{ ref('silver__traces') }}

--- a/models/gold/core/core__fact_traces.yml
+++ b/models/gold/core/core__fact_traces.yml
@@ -15,10 +15,16 @@ models:
       - name: TO_ADDRESS
         description: '{{ doc("base_traces_to") }}'
       - name: ETH_VALUE
-        description: '{{ doc("base_traces_value") }}'
+        description: 'Migration to `VALUE` column is in progress. Use `VALUE` instead.'
       - name: ETH_VALUE_PRECISE_RAW
-        description: '{{ doc("precise_amount_unadjusted") }}'
+        description: 'Migration to `VALUE_PRECISE_RAW` column is in progress. Use `VALUE_PRECISE_RAW` instead.'
       - name: ETH_VALUE_PRECISE
+        description: 'Migration to `VALUE_PRECISE` column is in progress. Use `VALUE_PRECISE` instead.'
+      - name: VALUE
+        description: '{{ doc("base_traces_value") }}'
+      - name: VALUE_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: VALUE_PRECISE
         description: '{{ doc("precise_amount_adjusted") }}'
       - name: GAS
         description: '{{ doc("base_traces_gas") }}'
@@ -44,6 +50,12 @@ models:
         description: The reason for the trace failure, if any.
       - name: TRACE_INDEX
         description: The index of the trace within the transaction. 
+      - name: FACT_TRACES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
 
 
 

--- a/models/gold/core/core__fact_traces.yml
+++ b/models/gold/core/core__fact_traces.yml
@@ -15,11 +15,11 @@ models:
       - name: TO_ADDRESS
         description: '{{ doc("base_traces_to") }}'
       - name: ETH_VALUE
-        description: 'Migration to `VALUE` column is in progress. Use `VALUE` instead.'
+        description: '{{ doc("amount_deprecation") }}'
       - name: ETH_VALUE_PRECISE_RAW
-        description: 'Migration to `VALUE_PRECISE_RAW` column is in progress. Use `VALUE_PRECISE_RAW` instead.'
+        description: '{{ doc("amount_deprecation") }}'
       - name: ETH_VALUE_PRECISE
-        description: 'Migration to `VALUE_PRECISE` column is in progress. Use `VALUE_PRECISE` instead.'
+        description: '{{ doc("amount_deprecation") }}'
       - name: VALUE
         description: '{{ doc("base_traces_value") }}'
       - name: VALUE_PRECISE_RAW

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -60,7 +60,7 @@ SELECT
     ) AS modified_timestamp,
     VALUE AS eth_value,
     eth_value_precise_raw,
-    eth_value_precise,
+    eth_value_precise
 FROM
     {{ ref('silver__transactions') }} A
     LEFT JOIN {{ ref('silver__state_hashes') }}

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -50,12 +50,14 @@ SELECT
             ['tx_hash']
         ) }}
     ) AS fact_transactions_id,
-    COALESCE(
-        inserted_timestamp,
+    GREATEST(
+        A.inserted_timestamp,
+        b.inserted_timestamp,
         '2000-01-01'
     ) AS inserted_timestamp,
-    COALESCE(
-        modified_timestamp,
+    GREATEST(
+        A.modified_timestamp,
+        b.modified_timestamp,
         '2000-01-01'
     ) AS modified_timestamp,
     VALUE AS eth_value,

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -50,16 +50,8 @@ SELECT
             ['tx_hash']
         ) }}
     ) AS fact_transactions_id,
-    GREATEST(
-        A.inserted_timestamp,
-        b.inserted_timestamp,
-        '2000-01-01'
-    ) AS inserted_timestamp,
-    GREATEST(
-        A.modified_timestamp,
-        b.modified_timestamp,
-        '2000-01-01'
-    ) AS modified_timestamp,
+    GREATEST(COALESCE(A.inserted_timestamp, '2000-01-01'), COALESCE(b.inserted_timestamp, '2000-01-01')) AS inserted_timestamp,
+    GREATEST(COALESCE(A.modified_timestamp, '2000-01-01'), COALESCE(b.modified_timestamp, '2000-01-01')) AS modified_timestamp,
     VALUE AS eth_value,
     value_precise_raw AS eth_value_precise_raw,
     value_precise AS eth_value_precise

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -14,9 +14,9 @@ SELECT
     origin_function_signature,
     from_address,
     to_address,
-    VALUE AS eth_value,
-    eth_value_precise_raw,
-    eth_value_precise,
+    VALUE,
+    eth_value_precise_raw AS value_precise_raw,
+    eth_value_precise AS value_precise,
     tx_fee,
     tx_fee_precise,
     gas_price,
@@ -43,7 +43,24 @@ SELECT
     tx_status AS status,
     r,
     s,
-    v
+    v,
+    COALESCE (
+        transactions_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash']
+        ) }}
+    ) AS fact_transactions_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp,
+    VALUE AS eth_value,
+    eth_value_precise_raw,
+    eth_value_precise,
 FROM
     {{ ref('silver__transactions') }} A
     LEFT JOIN {{ ref('silver__state_hashes') }}

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -21,11 +21,11 @@ models:
       - name: TO_ADDRESS
         description: '{{ doc("base_to_address") }}' 
       - name: ETH_VALUE
-        description: 'Migration to `VALUE` column is in progress. Use `VALUE` instead.' 
+        description: '{{ doc("amount_deprecation") }}'
       - name: ETH_VALUE_PRECISE_RAW
-        description: 'Migration to `VALUE_PRECISE_RAW` column is in progress. Use `VALUE_PRECISE_RAW` instead.'
+        description: '{{ doc("amount_deprecation") }}'
       - name: ETH_VALUE_PRECISE
-        description: 'Migration to `VALUE_PRECISE` column is in progress. Use `VALUE_PRECISE` instead.'
+        description: '{{ doc("amount_deprecation") }}'
       - name: VALUE
         description: '{{ doc("base_value") }}' 
       - name: VALUE_PRECISE_RAW

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -21,10 +21,16 @@ models:
       - name: TO_ADDRESS
         description: '{{ doc("base_to_address") }}' 
       - name: ETH_VALUE
-        description: '{{ doc("base_value") }}' 
+        description: 'Migration to `VALUE` column is in progress. Use `VALUE` instead.' 
       - name: ETH_VALUE_PRECISE_RAW
-        description: '{{ doc("precise_amount_unadjusted") }}'
+        description: 'Migration to `VALUE_PRECISE_RAW` column is in progress. Use `VALUE_PRECISE_RAW` instead.'
       - name: ETH_VALUE_PRECISE
+        description: 'Migration to `VALUE_PRECISE` column is in progress. Use `VALUE_PRECISE` instead.'
+      - name: VALUE
+        description: '{{ doc("base_value") }}' 
+      - name: VALUE_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: VALUE_PRECISE
         description: '{{ doc("precise_amount_adjusted") }}'
       - name: TX_FEE
         description: '{{ doc("base_tx_fee") }}' 
@@ -68,3 +74,9 @@ models:
         description: The s value of the transaction signature.
       - name: V
         description: The v value of the transaction signature.
+      - name: FACT_TRANSACTIONS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.sql
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.sql
@@ -2,14 +2,9 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta={
-    'database_tags':{
-        'table': {
-            'PROTOCOL': 'SUSHI, UNISWAP, BALANCER, SWAPBASED, BASESWAP, MAVERICK, DACKIE, WOOFI, AERODROME, CURVE',
-            'PURPOSE': 'DEX, LIQUIDITY, POOLS, LP, SWAPS',
-            }
-        }
-    }
+    meta ={ 'database_tags':{ 'table':{ 'PROTOCOL': 'SUSHI, UNISWAP, BALANCER, SWAPBASED, BASESWAP, MAVERICK, DACKIE, WOOFI, AERODROME, CURVE',
+    'PURPOSE': 'DEX, LIQUIDITY, POOLS, LP, SWAPS',
+    }} }
 ) }}
 
 SELECT
@@ -22,6 +17,20 @@ SELECT
     pool_name,
     tokens,
     symbols,
-    decimals
+    decimals,
+    COALESCE (
+        complete_dex_liquidity_pools_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['block_number','platform','version']
+        ) }}
+    ) AS dim_dex_liquidity_pools_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver_dex__complete_dex_liquidity_pools') }}

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.sql
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.sql
@@ -2,9 +2,14 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta ={ 'database_tags':{ 'table':{ 'PROTOCOL': 'SUSHI, UNISWAP, BALANCER, SWAPBASED, BASESWAP, MAVERICK, DACKIE, WOOFI, AERODROME, CURVE',
-    'PURPOSE': 'DEX, LIQUIDITY, POOLS, LP, SWAPS',
-    }} }
+    meta={
+    'database_tags':{
+        'table': {
+            'PROTOCOL': 'SUSHI, UNISWAP, BALANCER, SWAPBASED, BASESWAP, MAVERICK, DACKIE, WOOFI, AERODROME, CURVE',
+            'PURPOSE': 'DEX, LIQUIDITY, POOLS, LP, SWAPS',
+            }
+        }
+    }
 ) }}
 
 SELECT

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.yml
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.yml
@@ -24,3 +24,9 @@ models:
         description: '{{ doc("eth_dex_lp_symbols") }}'
       - name: DECIMALS
         description: '{{ doc("eth_dex_lp_decimals") }}'
+      - name: DIM_DEX_LIQUIDITY_POOLS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/defi/defi__ez_dex_swaps.sql
+++ b/models/gold/defi/defi__ez_dex_swaps.sql
@@ -3,7 +3,7 @@
     persist_docs ={ "relation": true,
     "columns": true },
     meta ={ 'database_tags':{ 'table':{ 'PROTOCOL': 'SUSHI, UNISWAP, BALANCER, SWAPBASED, BASESWAP, MAVERICK, DACKIE, WOOFI, AERODROME, CURVE',
-    'PURPOSE': 'DEX, SWAPS' } } }
+    'PURPOSE': 'DEX, SWAPS' }} }
 ) }}
 
 SELECT
@@ -30,6 +30,20 @@ SELECT
     token_out,
     symbol_in,
     symbol_out,
-    _log_id
+    _log_id,
+    COALESCE (
+        complete_dex_swaps_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash','event_index']
+        ) }}
+    ) AS ez_dex_swaps_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver_dex__complete_dex_swaps') }}

--- a/models/gold/defi/defi__ez_dex_swaps.sql
+++ b/models/gold/defi/defi__ez_dex_swaps.sql
@@ -2,8 +2,14 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta ={ 'database_tags':{ 'table':{ 'PROTOCOL': 'SUSHI, UNISWAP, BALANCER, SWAPBASED, BASESWAP, MAVERICK, DACKIE, WOOFI, AERODROME, CURVE',
-    'PURPOSE': 'DEX, SWAPS' }} }
+    meta={
+    'database_tags':{
+        'table': {
+            'PROTOCOL': 'SUSHI, UNISWAP, BALANCER, SWAPBASED, BASESWAP, MAVERICK, DACKIE, WOOFI, AERODROME, CURVE',
+            'PURPOSE': 'DEX, SWAPS',
+            }
+        }
+    }
 ) }}
 
 SELECT

--- a/models/gold/defi/defi__ez_dex_swaps.yml
+++ b/models/gold/defi/defi__ez_dex_swaps.yml
@@ -50,5 +50,11 @@ models:
         description: '{{ doc("eth_dex_swaps_amount_in_unadj") }}'
       - name: AMOUNT_OUT_UNADJ
         description: '{{ doc("eth_dex_swaps_amount_out_unadj") }}'
+      - name: EZ_DEX_SWAPS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
 
 

--- a/models/gold/defi/defi__ez_dex_swaps.yml
+++ b/models/gold/defi/defi__ez_dex_swaps.yml
@@ -39,7 +39,7 @@ models:
       - name: EVENT_INDEX
         description: '{{ doc("base_event_index") }}'
       - name: _LOG_ID
-        description: '{{ doc("base_log_id_events") }}'
+        description: '{{ doc("internal_column") }}'
       - name: ORIGIN_FUNCTION_SIGNATURE
         description: '{{ doc("base_tx_origin_sig") }}'
       - name: ORIGIN_FROM_ADDRESS

--- a/models/gold/nft/nft__ez_nft_sales.sql
+++ b/models/gold/nft/nft__ez_nft_sales.sql
@@ -2,7 +2,7 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }} }
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' } } }
 ) }}
 
 SELECT

--- a/models/gold/nft/nft__ez_nft_sales.sql
+++ b/models/gold/nft/nft__ez_nft_sales.sql
@@ -9,6 +9,7 @@ SELECT
     block_number,
     block_timestamp,
     tx_hash,
+    event_index,
     event_type,
     platform_address,
     platform_name,
@@ -35,7 +36,7 @@ SELECT
     COALESCE (
         complete_nft_sales_id,
         {{ dbt_utils.generate_surrogate_key(
-            ['block_number','platform_name','platform_exchange_version']
+            ['tx_hash', 'event_index', 'nft_address','tokenId','platform_exchange_version']
         ) }}
     ) AS ez_nft_sales_id,
     COALESCE(

--- a/models/gold/nft/nft__ez_nft_sales.sql
+++ b/models/gold/nft/nft__ez_nft_sales.sql
@@ -2,7 +2,7 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' } } }
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }} }
 ) }}
 
 SELECT
@@ -31,6 +31,20 @@ SELECT
     creator_fee_usd,
     origin_from_address,
     origin_to_address,
-    origin_function_signature
+    origin_function_signature,
+    COALESCE (
+        complete_nft_sales_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['block_number','platform_name','platform_exchange_version']
+        ) }}
+    ) AS ez_nft_sales_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__complete_nft_sales') }}

--- a/models/gold/nft/nft__ez_nft_sales.yml
+++ b/models/gold/nft/nft__ez_nft_sales.yml
@@ -10,6 +10,8 @@ models:
         description: '{{ doc("nft_blocktime") }}'
       - name: TX_HASH
         description: '{{ doc("nft_tx_hash") }}' 
+      - name: EVENT_INDEX
+        description: '{{ doc("nft_event_index") }}' 
       - name: EVENT_TYPE
         description: '{{ doc("nft_event_type") }}' 
       - name: PLATFORM_ADDRESS

--- a/models/gold/nft/nft__ez_nft_sales.yml
+++ b/models/gold/nft/nft__ez_nft_sales.yml
@@ -54,3 +54,9 @@ models:
         description: '{{ doc("nft_origin_to") }}'
       - name: ORIGIN_FUNCTION_SIGNATURE
         description: '{{ doc("nft_origin_sig") }}'
+      - name: EZ_NFT_SALES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/nft/nft__ez_nft_transfers.sql
+++ b/models/gold/nft/nft__ez_nft_transfers.sql
@@ -2,7 +2,7 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }} }
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' } } }
 ) }}
 
 SELECT

--- a/models/gold/nft/nft__ez_nft_transfers.sql
+++ b/models/gold/nft/nft__ez_nft_transfers.sql
@@ -10,6 +10,7 @@ SELECT
     block_number,
     tx_hash,
     event_index,
+    intra_event_index,
     event_type,
     contract_address AS nft_address,
     project_name,
@@ -20,7 +21,7 @@ SELECT
     COALESCE (
         nft_transfers_id,
         {{ dbt_utils.generate_surrogate_key(
-            ['tx_hash','event_index']
+            ['tx_hash','event_index','intra_event_index']
         ) }}
     ) AS ez_nft_transfers_id,
     COALESCE(

--- a/models/gold/nft/nft__ez_nft_transfers.sql
+++ b/models/gold/nft/nft__ez_nft_transfers.sql
@@ -2,7 +2,7 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' } } }
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }} }
 ) }}
 
 SELECT
@@ -16,6 +16,20 @@ SELECT
     from_address AS nft_from_address,
     to_address AS nft_to_address,
     tokenId,
-    erc1155_value
+    erc1155_value,
+    COALESCE (
+        nft_transfers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash','event_index']
+        ) }}
+    ) AS ez_nft_transfers_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__nft_transfers') }}

--- a/models/gold/nft/nft__ez_nft_transfers.yml
+++ b/models/gold/nft/nft__ez_nft_transfers.yml
@@ -26,3 +26,9 @@ models:
         description: '{{ doc("nft_tokenid") }}'
       - name: ERC1155_VALUE
         description: '{{ doc("nft_erc1155_value") }}'
+      - name: EZ_NFT_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/nft/nft__ez_nft_transfers.yml
+++ b/models/gold/nft/nft__ez_nft_transfers.yml
@@ -12,6 +12,8 @@ models:
         description: '{{ doc("nft_tx_hash") }}'
       - name: EVENT_INDEX
         description: '{{ doc("nft_event_index") }}'
+      - name: INTRA_EVENT_INDEX
+        description: '{{ doc("nft_intra_event_index") }}'
       - name: EVENT_TYPE
         description: '{{ doc("nft_event_type") }}'
       - name: NFT_ADDRESS

--- a/models/gold/price/price__dim_asset_metadata.sql
+++ b/models/gold/price/price__dim_asset_metadata.sql
@@ -10,6 +10,20 @@ SELECT
     symbol,
     NAME,
     decimals,
-    provider
+    provider,
+    COALESCE (
+        asset_metadata_all_providers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address','symbol','id','provider']
+        ) }}
+    ) AS dim_asset_metadata_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__asset_metadata_all_providers') }}

--- a/models/gold/price/price__dim_asset_metadata.yml
+++ b/models/gold/price/price__dim_asset_metadata.yml
@@ -23,3 +23,9 @@ models:
         description: The specific address representing the asset in a specific platform.
       - name: DECIMALS
         description: The number of decimal places the token needs adjusted where token values exist.
+      - name: DIM_ASSET_METADATA_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/price/price__ez_asset_metadata.sql
+++ b/models/gold/price/price__ez_asset_metadata.sql
@@ -9,6 +9,20 @@ SELECT
     id,
     symbol,
     NAME,
-    decimals
+    decimals,
+    COALESCE (
+        asset_metadata_priority_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address']
+        ) }}
+    ) AS ez_asset_metadata_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__asset_metadata_priority') }}

--- a/models/gold/price/price__ez_asset_metadata.yml
+++ b/models/gold/price/price__ez_asset_metadata.yml
@@ -18,3 +18,9 @@ models:
         description: The specific address representing the asset in a specific platform.
       - name: DECIMALS
         description: The number of decimal places the token needs adjusted where token values exist.
+      - name: EZ_ASSET_METADATA_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/price/price__ez_hourly_token_prices.sql
+++ b/models/gold/price/price__ez_hourly_token_prices.sql
@@ -10,6 +10,20 @@ SELECT
     symbol,
     decimals,
     price,
-    is_imputed
+    is_imputed,
+    COALESCE (
+        hourly_prices_priority_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address', 'hour']
+        ) }}
+    ) AS ez_hourly_token_prices_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__hourly_prices_priority') }}

--- a/models/gold/price/price__ez_hourly_token_prices.yml
+++ b/models/gold/price/price__ez_hourly_token_prices.yml
@@ -21,3 +21,9 @@ models:
         description: Closing price of the recorded hour in USD
       - name: IS_IMPUTED
         description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
+      - name: EZ_HOURLY_TOKEN_PRICES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/price/price__fact_hourly_token_prices.sql
+++ b/models/gold/price/price__fact_hourly_token_prices.sql
@@ -9,6 +9,20 @@ SELECT
     token_address,
     price,
     is_imputed,
-    provider
+    provider,
+    COALESCE (
+        hourly_prices_all_providers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address', 'hour', 'provider']
+        ) }}
+    ) AS fact_hourly_token_prices_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__hourly_prices_all_providers') }}

--- a/models/gold/price/price__fact_hourly_token_prices.yml
+++ b/models/gold/price/price__fact_hourly_token_prices.yml
@@ -14,3 +14,9 @@ models:
         description: Closing price of the recorded hour in USD
       - name: IS_IMPUTED
         description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
+      - name: FACT_HOURLY_TOKEN_PRICES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/silver/core/silver__blocks.sql
+++ b/models/silver/core/silver__blocks.sql
@@ -4,6 +4,7 @@
     unique_key = "block_number",
     cluster_by = "block_timestamp::date",
     tags = ['core','non_realtime'],
+    merge_exclude_columns = ["inserted_timestamp"],
     full_refresh = false
 ) }}
 
@@ -47,7 +48,13 @@ SELECT
     ) :: INT AS total_difficulty,
     DATA :transactionsRoot :: STRING AS transactions_root,
     DATA :uncles AS uncles,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_number']
+    ) }} AS blocks_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
 
 {% if is_incremental() %}

--- a/models/silver/core/silver__contracts.sql
+++ b/models/silver/core/silver__contracts.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'contract_address',
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -36,68 +37,73 @@ token_names AS (
         function_signature,
         read_output,
         utils.udf_hex_to_string(
-            SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_name
-    FROM
-        base_metadata
-    WHERE
-        function_signature = '0x06fdde03'
-        AND token_name IS NOT NULL
-),
-token_symbols AS (
-    SELECT
-        contract_address,
-        block_number,
-        function_signature,
-        read_output,
-        utils.udf_hex_to_string(
-            SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_symbol
-    FROM
-        base_metadata
-    WHERE
-        function_signature = '0x95d89b41'
-        AND token_symbol IS NOT NULL
-),
-token_decimals AS (
-    SELECT
-        contract_address,
-        CASE
-            WHEN read_output IS NOT NULL 
-                THEN utils.udf_hex_to_int(
-                    read_output :: STRING
-                ) 
-            ELSE NULL 
-        END AS token_decimals,
-        LENGTH(token_decimals) AS dec_length
-    FROM
-        base_metadata
-    WHERE
-        function_signature = '0x313ce567'
-        AND read_output IS NOT NULL
-        AND read_output <> '0x'
-),
-contracts AS (
-    SELECT
-        contract_address,
-        MAX(_inserted_timestamp) AS _inserted_timestamp
-    FROM
-        base_metadata
-    GROUP BY
-        1
-)
-SELECT
-    c1.contract_address :: STRING AS contract_address,
-    token_name,
-    TRY_TO_NUMBER(token_decimals) AS token_decimals,
-    token_symbol,
-    _inserted_timestamp
-FROM
-    contracts c1
-    LEFT JOIN token_names
-    ON c1.contract_address = token_names.contract_address
-    LEFT JOIN token_symbols
-    ON c1.contract_address = token_symbols.contract_address
-    LEFT JOIN token_decimals
-    ON c1.contract_address = token_decimals.contract_address
-    AND dec_length < 3 qualify(ROW_NUMBER() over(PARTITION BY c1.contract_address
-ORDER BY
-    _inserted_timestamp DESC)) = 1
+            SUBSTR(read_output,(64 * 2 + 3), len(read_output))) AS token_name
+            FROM
+                base_metadata
+            WHERE
+                function_signature = '0x06fdde03'
+                AND token_name IS NOT NULL
+        ),
+        token_symbols AS (
+            SELECT
+                contract_address,
+                block_number,
+                function_signature,
+                read_output,
+                utils.udf_hex_to_string(
+                    SUBSTR(read_output,(64 * 2 + 3), len(read_output))) AS token_symbol
+                    FROM
+                        base_metadata
+                    WHERE
+                        function_signature = '0x95d89b41'
+                        AND token_symbol IS NOT NULL
+                ),
+                token_decimals AS (
+                    SELECT
+                        contract_address,
+                        CASE
+                            WHEN read_output IS NOT NULL THEN utils.udf_hex_to_int(
+                                read_output :: STRING
+                            )
+                            ELSE NULL
+                        END AS token_decimals,
+                        LENGTH(token_decimals) AS dec_length
+                    FROM
+                        base_metadata
+                    WHERE
+                        function_signature = '0x313ce567'
+                        AND read_output IS NOT NULL
+                        AND read_output <> '0x'
+                ),
+                contracts AS (
+                    SELECT
+                        contract_address,
+                        MAX(_inserted_timestamp) AS _inserted_timestamp
+                    FROM
+                        base_metadata
+                    GROUP BY
+                        1
+                )
+            SELECT
+                c1.contract_address :: STRING AS contract_address,
+                token_name,
+                TRY_TO_NUMBER(token_decimals) AS token_decimals,
+                token_symbol,
+                _inserted_timestamp,
+                {{ dbt_utils.generate_surrogate_key(
+                    ['c1.contract_address']
+                ) }} AS contracts_id,
+                SYSDATE() AS inserted_timestamp,
+                SYSDATE() AS modified_timestamp,
+                '{{ invocation_id }}' AS _invocation_id
+            FROM
+                contracts c1
+                LEFT JOIN token_names
+                ON c1.contract_address = token_names.contract_address
+                LEFT JOIN token_symbols
+                ON c1.contract_address = token_symbols.contract_address
+                LEFT JOIN token_decimals
+                ON c1.contract_address = token_decimals.contract_address
+                AND dec_length < 3 qualify(ROW_NUMBER() over(PARTITION BY c1.contract_address
+            ORDER BY
+                _inserted_timestamp DESC)) = 1

--- a/models/silver/core/silver__created_contracts.sql
+++ b/models/silver/core/silver__created_contracts.sql
@@ -1,6 +1,7 @@
 {{ config (
     materialized = "incremental",
     unique_key = "created_contract_address",
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -11,7 +12,13 @@ SELECT
     to_address AS created_contract_address,
     from_address AS creator_address,
     input AS created_contract_input,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['to_address']
+    ) }} AS created_contracts_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('silver__traces') }}
 WHERE

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -5,6 +5,7 @@
     cluster_by = "block_timestamp::date",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     full_refresh = false,
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['decoded_logs','reorg']
 ) }}
 
@@ -192,7 +193,13 @@ SELECT
     DATA,
     event_removed,
     tx_status,
-    is_pending
+    is_pending,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS decoded_logs_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     new_records
 
@@ -217,7 +224,13 @@ SELECT
     DATA,
     event_removed,
     tx_status,
-    is_pending
+    is_pending,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS decoded_logs_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     missing_data
 {% endif %}

--- a/models/silver/core/silver__logs.sql
+++ b/models/silver/core/silver__logs.sql
@@ -176,7 +176,13 @@ FROM
 {% endif %}
 )
 SELECT
-    *
+    *,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS logs_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL qualify(ROW_NUMBER() over (PARTITION BY block_number, event_index
 ORDER BY

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     tags = ['core','non_realtime','reorg']
 ) }}
 

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -1,0 +1,108 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['core','non_realtime','reorg']
+) }}
+
+WITH eth_base AS (
+
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        identifier,
+        from_address,
+        to_address,
+        eth_value,
+        _call_id,
+        _inserted_timestamp,
+        eth_value_precise_raw,
+        eth_value_precise,
+        tx_position,
+        trace_index
+    FROM
+        {{ ref('silver__traces') }}
+    WHERE
+        eth_value > 0
+        AND tx_status = 'SUCCESS'
+        AND trace_status = 'SUCCESS'
+        AND TYPE NOT IN (
+            'DELEGATECALL',
+            'STATICCALL'
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+tx_table AS (
+    SELECT
+        block_number,
+        tx_hash,
+        from_address AS origin_from_address,
+        to_address AS origin_to_address,
+        origin_function_signature
+    FROM
+        {{ ref('silver__transactions') }}
+    WHERE
+        tx_hash IN (
+            SELECT
+                DISTINCT tx_hash
+            FROM
+                eth_base
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    tx_hash AS tx_hash,
+    block_number AS block_number,
+    block_timestamp AS block_timestamp,
+    identifier AS identifier,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    from_address,
+    to_address,
+    eth_value AS amount,
+    eth_value_precise_raw AS amount_precise_raw,
+    eth_value_precise AS amount_precise,
+    ROUND(
+        eth_value * price,
+        2
+    ) AS amount_usd,
+    _call_id,
+    _inserted_timestamp,
+    tx_position,
+    trace_index,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'trace_index']
+    ) }} AS native_transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    eth_base A
+    LEFT JOIN {{ ref('silver__hourly_prices_priority_eth') }}
+    ON DATE_TRUNC(
+        'hour',
+        A.block_timestamp
+    ) = HOUR
+    JOIN tx_table USING (
+        tx_hash,
+        block_number
+    )

--- a/models/silver/core/silver__traces.sql
+++ b/models/silver/core/silver__traces.sql
@@ -405,7 +405,13 @@ SELECT
     is_pending,
     _call_id,
     _inserted_timestamp,
-    eth_value_precise_raw
+    eth_value_precise_raw,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'trace_index']
+    ) }} AS traces_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL qualify(ROW_NUMBER() over(PARTITION BY block_number, tx_position, trace_index
 ORDER BY

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -375,7 +375,13 @@ SELECT
     tx_fee_precise,
     tx_type,
     _inserted_timestamp,
-    DATA
+    DATA,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash']
+    ) }} AS transactions_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL
 WHERE

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -239,7 +239,13 @@ heal_model AS (
         has_decimal,
         has_price,
         _log_id,
-        _inserted_timestamp
+        _inserted_timestamp,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }} AS transfers_id,
+        SYSDATE() AS inserted_timestamp,
+        SYSDATE() AS modified_timestamp,
+        '{{ invocation_id }}' AS _invocation_id
     FROM
         token_transfers
 
@@ -269,7 +275,13 @@ SELECT
     has_decimal,
     has_price,
     _log_id,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     heal_model
 {% endif %}

--- a/models/silver/core/silver__tx_count.sql
+++ b/models/silver/core/silver__tx_count.sql
@@ -1,15 +1,18 @@
 {{ config(
     materialized = 'incremental',
     unique_key = "block_number",
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
-SELECT
-    block_number,
-    MIN(_inserted_timestamp) AS _inserted_timestamp,
-    COUNT(*) AS tx_count
-FROM
-    {{ ref('silver__transactions') }}
+WITH base AS (
+
+    SELECT
+        block_number,
+        MIN(_inserted_timestamp) AS _inserted_timestamp,
+        COUNT(*) AS tx_count
+    FROM
+        {{ ref('silver__transactions') }}
 
 {% if is_incremental() %}
 WHERE
@@ -22,3 +25,14 @@ WHERE
 {% endif %}
 GROUP BY
     block_number
+)
+SELECT
+    *,
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_number']
+    ) }} AS tx_count_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    base

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -639,6 +639,12 @@ SELECT
   symbols,
   decimals,
   _id,
-  _inserted_timestamp
+  _inserted_timestamp,
+  {{ dbt_utils.generate_surrogate_key(
+    ['block_number','platform','version']
+  ) }} AS complete_dex_liquidity_pools_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  '{{ invocation_id }}' AS _invocation_id
 FROM
   FINAL

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -1174,7 +1174,13 @@ SELECT
   symbol_in,
   symbol_out,
   f._log_id,
-  f._inserted_timestamp
+  f._inserted_timestamp,
+  {{ dbt_utils.generate_surrogate_key(
+    ['f.tx_hash','f.event_index']
+  ) }} AS complete_dex_swaps_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  '{{ invocation_id }}' AS _invocation_id
 FROM
   FINAL f
   LEFT JOIN {{ ref('silver_dex__complete_dex_liquidity_pools') }}

--- a/models/silver/ethereum/silver__state_hashes.sql
+++ b/models/silver/ethereum/silver__state_hashes.sql
@@ -38,7 +38,16 @@ blocks AS (
     SELECT
         SEQ4() AS block_number
     FROM
-        TABLE(GENERATOR(rowcount => (SELECT max(block_number) as max_block FROM {{ref ('silver__blocks')}}) ))
+        TABLE(
+            GENERATOR(
+                rowcount => (
+                    SELECT
+                        MAX(block_number) AS max_block
+                    FROM
+                        {{ ref ('silver__blocks') }}
+                )
+            )
+        )
 )
 SELECT
     block_number,
@@ -51,7 +60,13 @@ SELECT
     state_prev_total_elements,
     state_min_block,
     state_max_block,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_number']
+    ) }} AS state_hashes_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     blocks
     INNER JOIN base

--- a/models/silver/labels/silver__labels.sql
+++ b/models/silver/labels/silver__labels.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'address',
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -13,7 +14,13 @@ SELECT
     label_type,
     label_subtype,
     address_name,
-    project_name
+    project_name,
+    {{ dbt_utils.generate_surrogate_key(
+        ['address']
+    ) }} AS labels_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__labels') }}
 WHERE

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -373,7 +373,7 @@ SELECT
     _log_id,
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(
-        ['block_number','platform_name','platform_exchange_version']
+        ['nft_address','tokenId','platform_exchange_version','_log_id']
     ) }} AS complete_nft_sales_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -371,7 +371,13 @@ SELECT
     nft_log_id,
     input_data,
     _log_id,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_number','platform_name','platform_exchange_version']
+    ) }} AS complete_nft_sales_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     final_joins qualify(ROW_NUMBER() over(PARTITION BY nft_log_id
 ORDER BY

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -12,6 +12,7 @@ WITH nft_base_models AS (
         block_number,
         block_timestamp,
         tx_hash,
+        event_index,
         event_type,
         platform_address,
         platform_name,
@@ -53,6 +54,7 @@ SELECT
     block_number,
     block_timestamp,
     tx_hash,
+    event_index,
     event_type,
     platform_address,
     platform_name,
@@ -164,6 +166,7 @@ final_base AS (
         block_number,
         block_timestamp,
         tx_hash,
+        event_index,
         event_type,
         platform_address,
         platform_name,
@@ -273,6 +276,7 @@ label_fill_sales AS (
         block_number,
         block_timestamp,
         tx_hash,
+        event_index,
         event_type,
         platform_address,
         platform_name,
@@ -338,6 +342,7 @@ SELECT
     block_number,
     block_timestamp,
     tx_hash,
+    event_index,
     event_type,
     platform_address,
     platform_name,
@@ -373,7 +378,7 @@ SELECT
     _log_id,
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(
-        ['nft_address','tokenId','platform_exchange_version','_log_id']
+        ['tx_hash', 'event_index', 'nft_address','tokenId','platform_exchange_version']
     ) }} AS complete_nft_sales_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,

--- a/models/silver/nft/silver__complete_nft_sales.yml
+++ b/models/silver/nft/silver__complete_nft_sales.yml
@@ -28,6 +28,9 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_INDEX
+        tests:
+          - not_null
       - name: PLATFORM_ADDRESS
         tests:
           - not_null

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -41,9 +41,7 @@ WITH base AS (
 {% if is_incremental() %}
 AND TO_TIMESTAMP_NTZ(_inserted_timestamp) >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        )
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -234,6 +234,7 @@ all_transfers AS (
         erc1155_value,
         _inserted_timestamp,
         event_index,
+        1 AS intra_event_index,
         'erc721_Transfer' AS token_transfer_type,
         CONCAT(
             _log_id,
@@ -256,6 +257,7 @@ all_transfers AS (
         erc1155_value,
         _inserted_timestamp,
         event_index,
+        1 AS intra_event_index,
         'erc1155_TransferSingle' AS token_transfer_type,
         CONCAT(
             _log_id,
@@ -280,6 +282,7 @@ all_transfers AS (
         erc1155_value,
         _inserted_timestamp,
         event_index,
+        intra_event_index,
         'erc1155_TransferBatch' AS token_transfer_type,
         CONCAT(
             _log_id,
@@ -301,6 +304,7 @@ transfer_base AS (
         block_timestamp,
         tx_hash,
         event_index,
+        intra_event_index,
         contract_address,
         C.token_name AS project_name,
         from_address,
@@ -328,6 +332,7 @@ fill_transfers AS (
         t.block_timestamp,
         t.tx_hash,
         t.event_index,
+        t.intra_event_index,
         t.contract_address,
         C.token_name AS project_name,
         t.from_address,
@@ -356,6 +361,7 @@ final_base AS (
         block_timestamp,
         tx_hash,
         event_index,
+        intra_event_index,
         contract_address,
         project_name,
         from_address,
@@ -376,6 +382,7 @@ SELECT
     block_timestamp,
     tx_hash,
     event_index,
+    intra_event_index,
     contract_address,
     project_name,
     from_address,
@@ -395,6 +402,7 @@ SELECT
     block_timestamp,
     tx_hash,
     event_index,
+    intra_event_index,
     contract_address,
     project_name,
     from_address,
@@ -406,7 +414,7 @@ SELECT
     _log_id,
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(
-        ['tx_hash','event_index']
+        ['tx_hash','event_index','intra_event_index']
     ) }} AS nft_transfers_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -404,7 +404,13 @@ SELECT
     event_type,
     token_transfer_type,
     _log_id,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash','event_index']
+    ) }} AS nft_transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     final_base qualify ROW_NUMBER() over (
         PARTITION BY _log_id

--- a/models/silver/nft/silver__nft_transfers.yml
+++ b/models/silver/nft/silver__nft_transfers.yml
@@ -28,6 +28,12 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: INTRA_EVENT_INDEX
+        tests:
+          - not_null
       - name: CONTRACT_ADDRESS
         tests:
           - not_null

--- a/models/silver/prices/silver__asset_metadata_all_providers.sql
+++ b/models/silver/prices/silver__asset_metadata_all_providers.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    merge_exclude_columns = ["inserted_timestamp"],
     unique_key = ['token_address','symbol','id','provider'],
     tags = ['non_realtime']
 ) }}
@@ -14,7 +15,13 @@ SELECT
     token_name AS NAME,
     token_decimals AS decimals,
     provider,
-    p._inserted_timestamp
+    p._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['token_address','symbol','id','provider']
+    ) }} AS asset_metadata_all_providers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__asset_metadata_all_providers') }}
     p

--- a/models/silver/prices/silver__hourly_prices_all_providers.sql
+++ b/models/silver/prices/silver__hourly_prices_all_providers.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['token_address', 'hour', 'provider'],
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -10,7 +11,13 @@ SELECT
     provider,
     price,
     is_imputed,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['token_address', 'hour', 'provider']
+    ) }} AS hourly_prices_all_providers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__hourly_prices_all_providers') }}
 WHERE

--- a/models/silver/prices/silver__hourly_prices_priority.sql
+++ b/models/silver/prices/silver__hourly_prices_priority.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['token_address', 'hour'],
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -14,7 +15,13 @@ SELECT
         C.token_symbol,
         m.symbol
     ) AS symbol,
-    C.token_decimals AS decimals
+    C.token_decimals AS decimals,
+    {{ dbt_utils.generate_surrogate_key(
+        ['p.token_address', 'p.hour']
+    ) }} AS hourly_prices_priority_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__hourly_prices_priority') }}
     p
@@ -30,8 +37,8 @@ WHERE
 AND p._inserted_timestamp >= (
     SELECT
         MAX(
-                _inserted_timestamp
-            ) - INTERVAL '24 hours'
+            _inserted_timestamp
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/prices/silver__hourly_prices_priority_eth.sql
+++ b/models/silver/prices/silver__hourly_prices_priority_eth.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['token_address', 'hour'],
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -9,7 +10,13 @@ SELECT
     token_address,
     price,
     is_imputed,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['token_address', 'hour']
+    ) }} AS hourly_prices_priority_eth_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__hourly_prices_priority_eth') }}
 WHERE


### PR DESCRIPTION
- adds export columns: `<pk>`, `inserted_timestamp`, and `modified_timestamp` to gold
- adds `_invocation_id` to silver
- creates `silver__native_transfers` to replace gold table logic, also builds `core.ez_native_transfers` to replace `core.ez_eth_transfers`
- adds generic columns to `fact_traces` and `fact_transactions`, deprecation notice on impacted columns
- adds deprecation notice to any internal columns, denoted with `_`. This is mostly just removing `_log_id` and `_inserted_timestamp` from gold to be consistent
- command 1: `dbt run -m models/silver/core/silver__native_transfers.sql models/silver/nft/silver__complete_nft_sales.sql models/silver/nft/silver__nft_transfers.sql models/silver/core/silver__transactions.sql models/silver/core/tests --full-refresh`
- command 2: `dbt run -m models/silver models/gold`