### PR TITLE
add-new-moonwell-deployer-address 

### DIFF
--- a/models/silver/defi/lending/moonwell/silver__moonwell_asset_details.sql
+++ b/models/silver/defi/lending/moonwell/silver__moonwell_asset_details.sql
@@ -6,7 +6,14 @@
     tags = ['reorg','curated']
 ) }}
 
-WITH log_pull AS (
+WITH 
+contracts AS (
+    SELECT
+        *
+    FROM
+        {{ ref('silver__contracts') }}
+),
+log_pull AS (
 
     SELECT
         tx_hash,
@@ -19,9 +26,11 @@ WITH log_pull AS (
         {{ ref('silver__logs') }}
     WHERE
         topics [0] :: STRING = '0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d'
-        AND origin_from_address IN (LOWER('0xc3f9774af21a030ab785cb45510ba9edc9d0c8cd'),LOWER('0x3073fCAD986fbE9F94CC6Caa44f76c12e34516d4'))
-
-
+        AND origin_from_address IN (
+            LOWER('0xc3f9774af21a030ab785cb45510ba9edc9d0c8cd'),
+            LOWER('0x3073fCAD986fbE9F94CC6Caa44f76c12e34516d4'),
+            LOWER('0xc84065601e39a623d75dfddd278346b9778d8943')
+        )
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
@@ -47,12 +56,6 @@ traces_pull AS (
                 log_pull
         )
         AND identifier = 'STATICCALL_0_2'
-),
-contracts AS (
-    SELECT
-        *
-    FROM
-        {{ ref('silver__contracts') }}
 ),
 contract_pull AS (
     SELECT

--- a/models/silver/defi/lending/sonne/silver__sonne_asset_details.sql
+++ b/models/silver/defi/lending/sonne/silver__sonne_asset_details.sql
@@ -20,12 +20,6 @@ WITH log_pull AS (
     WHERE
         topics [0] :: STRING = '0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d'
         AND origin_from_address = LOWER('0xFb59Ce8986943163F14C590755b29dB2998F2322')
-        {# IN (
-            LOWER('0xFb59Ce8986943163F14C590755b29dB2998F2322'),
-            LOWER('0x655284bebcc6e1dffd098ec538750d43b57bc743'),
-            LOWER('0xde6d6f23aabbdc9469c8907ece7c379f98e4cb75')
-        ) #}
-
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
@@ -68,10 +62,6 @@ contract_pull AS (
         C.token_symbol,
         C.token_decimals,
         t.underlying_asset,
-        {# CASE
-            WHEN l.contract_address = LOWER('0xf7B5965f5C117Eb1B5450187c9DcFccc3C317e8E') THEN '0x4200000000000000000000000000000000000006' --WETH
-            ELSE t.underlying_asset
-        END AS underlying_asset, #}
         l._inserted_timestamp,
         l._log_id
     FROM


### PR DESCRIPTION
`dbt run -m models/silver/defi/lending/moonwell --full-refresh && dbt run --vars '{"HEAL_CURATED_MODEL":"moonwell"}' -m models/silver/defi/lending/complete_lending && dbt test -m models/silver/defi/lending`
* This will fix for now, but creating a ticket to update all of our comp fork models to not need the `origin_from_address` filter as it causes us to miss stuff when the protocol deploys from a new address.