### PR TITLE
AN-5443/aave-token-model-errors

### DIFF
--- a/models/silver/defi/lending/aave/silver__aave_flashloans.sql
+++ b/models/silver/defi/lending/aave/silver__aave_flashloans.sql
@@ -19,7 +19,7 @@ WITH flashloan AS (
         contract_address,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS target_address,
-        origin_to_address AS initiator_address,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 27, 40)) AS initiator_address,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS aave_market,
         utils.udf_hex_to_int(
             segmented_data [1] :: STRING

--- a/models/silver/defi/lending/aave/silver__aave_tokens.sql
+++ b/models/silver/defi/lending/aave/silver__aave_tokens.sql
@@ -11,6 +11,7 @@ WITH DECODE AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS underlying_asset,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS aave_version_pool,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) :: STRING AS treasury_address,
         utils.udf_hex_to_int(
             SUBSTR(
                 segmented_data [2] :: STRING,
@@ -56,6 +57,7 @@ a_token_step_1 AS (
         segmented_data,
         underlying_asset,
         aave_version_pool,
+        treasury_address,
         atoken_decimals,
         atoken_name,
         atoken_symbol,
@@ -95,6 +97,7 @@ a_token_step_2 AS (
         segmented_data,
         underlying_asset,
         aave_version_pool,
+        treasury_address,
         atoken_decimals,
         atoken_name,
         atoken_symbol,
@@ -107,6 +110,7 @@ a_token_step_2 AS (
 SELECT
     A.atoken_created_block,
     a.aave_version_pool,
+    A.treasury_address,
     A.atoken_symbol AS atoken_symbol,
     A.a_token_address AS atoken_address,
     b.atoken_stable_debt_address,
@@ -125,6 +129,7 @@ FROM
     INNER JOIN debt_tokens b
     ON A.a_token_address = b.atoken_address
     INNER JOIN {{ ref('silver__contracts') }} C
-    ON contract_address = A.underlying_asset qualify(ROW_NUMBER() over(PARTITION BY atoken_address
+    ON contract_address = A.underlying_asset
+    WHERE treasury_address = '0xba9424d650a4f5c80a0da641254d1acce2a37057'qualify(ROW_NUMBER() over(PARTITION BY atoken_address
 ORDER BY
     a.atoken_created_block DESC)) = 1

--- a/models/silver/defi/lending/granary/silver__granary_flashloans.sql
+++ b/models/silver/defi/lending/granary/silver__granary_flashloans.sql
@@ -38,7 +38,7 @@ flashloan AS (
         contract_address,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS target_address,
-        origin_to_address AS initiator_address,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 27, 40)) AS initiator_address,
         CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS granary_market,
         utils.udf_hex_to_int(
             segmented_data [0] :: STRING

--- a/models/silver/defi/lending/seamless/silver__seamless_flashloans.sql
+++ b/models/silver/defi/lending/seamless/silver__seamless_flashloans.sql
@@ -38,7 +38,7 @@ flashloan AS (
         contract_address,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS target_address,
-        origin_to_address AS initiator_address,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 27, 40)) AS initiator_address,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS seamless_market,
         utils.udf_hex_to_int(
             segmented_data [1] :: STRING

--- a/models/silver/defi/lending/seamless/silver__seamless_tokens.sql
+++ b/models/silver/defi/lending/seamless/silver__seamless_tokens.sql
@@ -11,6 +11,7 @@ WITH DECODE AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS underlying_asset,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS seamless_version_pool,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) :: STRING AS treasury_address,
         utils.udf_hex_to_int(
             SUBSTR(
                 segmented_data [2] :: STRING,
@@ -56,6 +57,7 @@ a_token_step_1 AS (
         segmented_data,
         underlying_asset,
         seamless_version_pool,
+        treasury_address,
         atoken_decimals,
         atoken_name,
         atoken_symbol,
@@ -95,6 +97,7 @@ a_token_step_2 AS (
         segmented_data,
         underlying_asset,
         seamless_version_pool,
+        treasury_address,
         atoken_decimals,
         atoken_name,
         atoken_symbol,
@@ -107,6 +110,7 @@ a_token_step_2 AS (
 SELECT
     A.atoken_created_block,
     seamless_version_pool,
+    A.treasury_address,
     A.atoken_symbol AS atoken_symbol,
     A.a_token_address AS atoken_address,
     b.atoken_stable_debt_address,
@@ -125,6 +129,7 @@ FROM
     INNER JOIN debt_tokens b
     ON A.a_token_address = b.atoken_address
     INNER JOIN {{ ref('silver__contracts') }} C
-    ON contract_address = A.underlying_asset qualify(ROW_NUMBER() over(PARTITION BY atoken_address
+    ON contract_address = A.underlying_asset 
+where treasury_address = '0x982f3a0e3183896f9970b8a9ea6b69cd53af1089' qualify(ROW_NUMBER() over(PARTITION BY atoken_address
 ORDER BY
     a.atoken_created_block DESC)) = 1


### PR DESCRIPTION
`dbt run -m models/silver/defi/lending/aave/silver__aave_tokens.sql models/silver/defi/lending/granary/silver__granary_tokens.sql models/silver/defi/lending/aave/silver__aave_tokens.sql --full-refresh` --only need to FR token models, Aave lending uses hardcoded address, other protocols didn't pick up any other extra tokens.