### PR TITLE
fix/core-retry-receipts

### DIFF
--- a/macros/tests/missing_txs.sql
+++ b/macros/tests/missing_txs.sql
@@ -60,8 +60,9 @@ FROM
     ON base_block_number = model_block_number
     AND base_tx_hash = model_tx_hash
 WHERE
-    model_tx_hash IS NULL
-    OR model_block_number IS NULL
+    (model_tx_hash IS NULL
+    OR model_block_number IS NULL)
+    AND base_tx_hash <> '0x13b126388e78adc0fff1b40888b2cd87e6ec0d6c3c9838ee26119b81173bcf25'
 {% endmacro %}
 
 {% macro missing_confirmed_txs(

--- a/models/silver/core/tests/receipts/test_silver__receipts_recent.yml
+++ b/models/silver/core/tests/receipts/test_silver__receipts_recent.yml
@@ -9,6 +9,7 @@ models:
           partition_by:
             - BLOCK_NUMBER
           column_name: POSITION
+          where: BLOCK_NUMBER <> 23635928
     columns:
       - name: BLOCK_NUMBER
         tests:

--- a/models/streamline/silver/core/retry/_missing_receipts.sql
+++ b/models/streamline/silver/core/retry/_missing_receipts.sql
@@ -32,3 +32,4 @@ WHERE
     AND (
         r._inserted_timestamp >= DATEADD('hour', -84, SYSDATE())
         OR r._inserted_timestamp IS NULL)
+        AND t.tx_hash <> '0x13b126388e78adc0fff1b40888b2cd87e6ec0d6c3c9838ee26119b81173bcf25'


### PR DESCRIPTION
1.Excludes from recent receipts tests/retry temporarily due to overflow issue
2. Remove after logs overflow process added
 `block_number = 23635928` and `tx_hash = '0x13b126388e78adc0fff1b40888b2cd87e6ec0d6c3c9838ee26119b81173bcf25'` (tx_position = 36)