### PR TITLE
pcsv3-swap-fix

### DIFF
--- a/models/silver/defi/dex/pancakeswap/silver_dex__pancakeswap_v3_swaps.sql
+++ b/models/silver/defi/dex/pancakeswap/silver_dex__pancakeswap_v3_swaps.sql
@@ -84,12 +84,12 @@ base_swaps AS (
         token0_address,
         token1_address,
         CASE
-            WHEN amount0 < 0 THEN token0_address
+            WHEN amount0 > 0 THEN token0_address
             ELSE token1_address
         END AS token_in,
         CASE
-            WHEN amount0 > 0 THEN token0_address
-            ELSE token1_address
+            WHEN amount1 < 0 THEN token1_address
+            ELSE token0_address
         END AS token_out,
         fee,
         tick_spacing,


### PR DESCRIPTION
fix `token_in` and `token_out` logic. 


`dbt run -m models/silver/defi/dex/pancakeswap/silver_dex__pancakeswap_v3_swaps.sql --full-refresh && dbt run -m models/silver/defi/dex/silver_dex__complete_dex_swaps.sql --vars '{"HEAL_MODELS":"pancakeswap_v3"}'`